### PR TITLE
Allow downloading just originals

### DIFF
--- a/lib/flickr.php
+++ b/lib/flickr.php
@@ -61,7 +61,8 @@ function getPhotoDate($info) {
 // can be an item from flickr.people.getPhotos or an item from flickr.photos.getInfo
 // skip_if_exists will check for the metadata file and skip the entire photo if found
 // skip_download_if_exists will make all API calls, but will skip downloading the images if they already exist
-function savePhoto($info, $skip_if_exists=true, $skip_download_if_exists=true) {
+// originals_only only downloads sizes that contain 'Original' and skip the rest
+function savePhoto($info, $skip_if_exists=true, $skip_download_if_exists=true, $originals_only=false) {
   global $flickr;
 
   $date = getPhotoDate($info);
@@ -138,6 +139,9 @@ function savePhoto($info, $skip_if_exists=true, $skip_download_if_exists=true) {
 
   foreach($sizes as $size) {
     if($size['label'] == 'Video Player')
+      continue;
+
+    if($originals_only && !str_contains($size['label'], 'Original'))
       continue;
 
     $filename = $folder.'/'.sizeToFilename($info['id'], $size);

--- a/scripts/download.php
+++ b/scripts/download.php
@@ -22,6 +22,7 @@ if(isset($argv[1]))
 else
   $skip_if_exists = true;
 
+$originals_only = $_ENV['ORIGINALS_ONLY']  == 'true';
 
 // Process the current page
 $photos = processPage($page);
@@ -34,7 +35,7 @@ for($i=$page+1; $i<$photos['pages']; $i++) {
 
 
 function processPage($page) {
-  global $flickr, $progress, $progressFile, $skip_if_exists;
+  global $flickr, $progress, $progressFile, $skip_if_exists, $originals_only;
 
   echo "Processing page $page\n";
 
@@ -64,7 +65,7 @@ function processPage($page) {
 
   try {
     foreach($photos['photo'] as $photo) {
-      savePhoto($photo, $skip_if_exists);
+      savePhoto($photo, $skip_if_exists, true, $originals_only);
     }
   } catch(Exception $e) {
     $message = $e->getMessage();


### PR DESCRIPTION
This allows (by settings `ORIGINALS_ONLY=true` in `.env`) to just download the files with 'Original' in the filename, saving some network and disk space at the expense of thumbnails. 

Closes https://github.com/aaronpk/Flickr-Archivr/issues/1.